### PR TITLE
Manage all fields for button in model

### DIFF
--- a/lib/shirley.dart
+++ b/lib/shirley.dart
@@ -20,7 +20,7 @@ class Shirley extends HookWidget {
     final jsonString = useState('');
 
     final backgroundColor = useState<Color>(Color.fromRGBO(131, 217, 119, 1));
-    final content = useState('');
+    final content = useState('1.Normal Button');
 
     final buttonTextEditingController =
         useTextEditingController(text: '1.Normal Button');

--- a/lib/shirley.dart
+++ b/lib/shirley.dart
@@ -9,7 +9,6 @@ import 'package:shirley/src/ui/components/field_setting_container.dart';
 import 'package:shirley/src/ui/components/preset_button.dart';
 import 'package:shirley/src/ui/components/preview_container.dart';
 import 'package:syntax_highlight/syntax_highlight.dart';
-import 'package:dart_style/dart_style.dart';
 
 class Shirley extends HookWidget {
   const Shirley({super.key});
@@ -80,12 +79,7 @@ class Shirley extends HookWidget {
           ..methods.addAll(methods);
       });
 
-      final formattedCode = DartFormatter(
-        languageVersion: DartFormatter.latestLanguageVersion,
-        indent: 2,
-      ).format('${shirleyButtonClass.accept(DartEmitter.scoped())}');
-
-      code.value = formattedCode;
+      code.value = '${shirleyButtonClass.accept(DartEmitter.scoped())}';
 
       jsonString.value = '''
 {

--- a/lib/shirley.dart
+++ b/lib/shirley.dart
@@ -3,6 +3,7 @@ import 'package:devtools_extensions/api.dart';
 import 'package:devtools_extensions/devtools_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:shirley/src/common/widget.dart';
 import 'package:shirley/src/extension/color.dart';
 import 'package:shirley/src/ui/components/field_setting_container.dart';
 import 'package:shirley/src/ui/components/preset_button.dart';
@@ -26,7 +27,7 @@ class Shirley extends HookWidget {
         useTextEditingController(text: '1.Normal Button');
 
     useEffect(() {
-      WidgetsBinding.instance.addPostFrameCallback((_) async {
+      afterBuild((_) async {
         await Highlighter.initialize(['dart']);
 
         theme.value = await HighlighterTheme.loadDarkTheme();

--- a/lib/shirley.dart
+++ b/lib/shirley.dart
@@ -30,58 +30,63 @@ class Shirley extends HookWidget {
         await Highlighter.initialize(['dart']);
 
         theme.value = await HighlighterTheme.loadDarkTheme();
+      });
 
-        final elevatedButton = refer('ElevatedButton').newInstance(
-          [],
-          {
-            'child': refer('Text').newInstance([
-              literalString(buttonTextEditingController.text),
-            ]),
-            'style': refer('ElevatedButton.styleFrom').call([], {
-              'backgroundColor': refer('Colors.fromRGBO').call([
-                literalNum(backgroundColor.value.redValue),
-                literalNum(backgroundColor.value.greenValue),
-                literalNum(backgroundColor.value.blueValue),
-                literalNum(1)
-              ])
-            }),
-            'onPressed': Method((builder) => builder
-              ..lambda = true
-              ..body = Code('() {}')).closure,
-          },
-        );
+      return;
+    }, []);
 
-        final parameter = Parameter(
+    useEffect(() {
+      final elevatedButton = refer('ElevatedButton').newInstance(
+        [],
+        {
+          'child': refer('Text').newInstance([
+            literalString(buttonTextEditingController.text),
+          ]),
+          'style': refer('ElevatedButton.styleFrom').call([], {
+            'backgroundColor': refer('Colors.fromRGBO').call([
+              literalNum(backgroundColor.value.redValue),
+              literalNum(backgroundColor.value.greenValue),
+              literalNum(backgroundColor.value.blueValue),
+              literalNum(1)
+            ])
+          }),
+          'onPressed': Method((builder) => builder
+            ..lambda = true
+            ..body = Code('() {}')).closure,
+        },
+      );
+
+      final parameter = Parameter(
+        (builder) => builder
+          ..name = 'context'
+          ..type = refer('BuildContext'),
+      );
+
+      final methods = [
+        Method(
           (builder) => builder
-            ..name = 'context'
-            ..type = refer('BuildContext'),
-        );
+            ..name = 'build'
+            ..requiredParameters.add(parameter)
+            ..body = Code('return ${elevatedButton.accept(DartEmitter())};')
+            ..returns = refer('Widget'),
+        ),
+      ];
 
-        final methods = [
-          Method(
-            (builder) => builder
-              ..name = 'build'
-              ..requiredParameters.add(parameter)
-              ..body = Code('return ${elevatedButton.accept(DartEmitter())};')
-              ..returns = refer('Widget'),
-          ),
-        ];
+      final shirleyButtonClass = Class((builder) {
+        builder
+          ..name = 'ShirleyButton'
+          ..extend = refer('StatelessWidget')
+          ..methods.addAll(methods);
+      });
 
-        final shirleyButtonClass = Class((builder) {
-          builder
-            ..name = 'ShirleyButton'
-            ..extend = refer('StatelessWidget')
-            ..methods.addAll(methods);
-        });
+      final formattedCode = DartFormatter(
+        languageVersion: DartFormatter.latestLanguageVersion,
+        indent: 2,
+      ).format('${shirleyButtonClass.accept(DartEmitter.scoped())}');
 
-        final formattedCode = DartFormatter(
-          languageVersion: DartFormatter.latestLanguageVersion,
-          indent: 2,
-        ).format('${shirleyButtonClass.accept(DartEmitter.scoped())}');
+      code.value = formattedCode;
 
-        code.value = formattedCode;
-
-        jsonString.value = '''
+      jsonString.value = '''
 {
   "type": "elevated_button",
   "args": {
@@ -97,7 +102,6 @@ class Shirley extends HookWidget {
   }
 }
 ''';
-      });
 
       return;
     }, [backgroundColor.value, content.value]);

--- a/lib/shirley.dart
+++ b/lib/shirley.dart
@@ -110,7 +110,7 @@ class Shirley extends HookWidget {
                           cloned.textStyle = textStyle;
                           buttonField.value = cloned;
                         },
-                        onButtonStyleChanged: (buttonStyle) {
+                        onButtonStyleFieldChanged: (buttonStyle) {
                           final cloned = buttonField.value.clone();
                           cloned.buttonStyle = buttonStyle;
                           buttonField.value = cloned;

--- a/lib/shirley.dart
+++ b/lib/shirley.dart
@@ -110,9 +110,7 @@ class Shirley extends HookWidget {
                           cloned.textStyle = textStyle;
                           buttonField.value = cloned;
                         },
-                        onColorChanged: (color) {
-                          final buttonStyle =
-                              ElevatedButton.styleFrom(backgroundColor: color);
+                        onButtonStyleChanged: (buttonStyle) {
                           final cloned = buttonField.value.clone();
                           cloned.buttonStyle = buttonStyle;
                           buttonField.value = cloned;

--- a/lib/shirley.dart
+++ b/lib/shirley.dart
@@ -1,10 +1,9 @@
-import 'package:code_builder/code_builder.dart';
 import 'package:devtools_extensions/api.dart';
 import 'package:devtools_extensions/devtools_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:shirley/src/common/widget.dart';
-import 'package:shirley/src/extension/color.dart';
+import 'package:shirley/src/model/button_field.dart';
 import 'package:shirley/src/ui/components/field_setting_container.dart';
 import 'package:shirley/src/ui/components/preset_button.dart';
 import 'package:shirley/src/ui/components/preview_container.dart';
@@ -19,11 +18,13 @@ class Shirley extends HookWidget {
     final code = useState('');
     final jsonString = useState('');
 
-    final backgroundColor = useState<Color>(Color.fromRGBO(131, 217, 119, 1));
-    final content = useState('1.Normal Button');
-
-    final buttonTextEditingController =
-        useTextEditingController(text: '1.Normal Button');
+    final buttonField = useState(ButtonField(
+      text: '1.Normal Button',
+      textStyle: TextStyle(fontSize: 14),
+      buttonStyle: ElevatedButton.styleFrom(
+        backgroundColor: Color.fromRGBO(131, 217, 119, 1),
+      ),
+    ));
 
     useEffect(() {
       afterBuild((_) async {
@@ -36,70 +37,11 @@ class Shirley extends HookWidget {
     }, []);
 
     useEffect(() {
-      final elevatedButton = refer('ElevatedButton').newInstance(
-        [],
-        {
-          'child': refer('Text').newInstance([
-            literalString(buttonTextEditingController.text),
-          ]),
-          'style': refer('ElevatedButton.styleFrom').call([], {
-            'backgroundColor': refer('Colors.fromRGBO').call([
-              literalNum(backgroundColor.value.redValue),
-              literalNum(backgroundColor.value.greenValue),
-              literalNum(backgroundColor.value.blueValue),
-              literalNum(1)
-            ])
-          }),
-          'onPressed': Method((builder) => builder
-            ..lambda = true
-            ..body = Code('() {}')).closure,
-        },
-      );
-
-      final parameter = Parameter(
-        (builder) => builder
-          ..name = 'context'
-          ..type = refer('BuildContext'),
-      );
-
-      final methods = [
-        Method(
-          (builder) => builder
-            ..name = 'build'
-            ..requiredParameters.add(parameter)
-            ..body = Code('return ${elevatedButton.accept(DartEmitter())};')
-            ..returns = refer('Widget'),
-        ),
-      ];
-
-      final shirleyButtonClass = Class((builder) {
-        builder
-          ..name = 'ShirleyButton'
-          ..extend = refer('StatelessWidget')
-          ..methods.addAll(methods);
-      });
-
-      code.value = '${shirleyButtonClass.accept(DartEmitter.scoped())}';
-
-      jsonString.value = '''
-{
-  "type": "elevated_button",
-  "args": {
-    "child": {
-      "type": "text",
-      "args": {
-        "text": "${content.value}"
-      }
-    },
-    "style": {
-      "backgroundColor": "${backgroundColor.value.toHex}"
-    }
-  }
-}
-''';
+      code.value = buttonField.value.toCode();
+      jsonString.value = buttonField.value.toJsonString();
 
       return;
-    }, [backgroundColor.value, content.value]);
+    }, [buttonField.value]);
 
     return DevToolsExtension(
       eventHandlers: {
@@ -157,9 +99,14 @@ class Shirley extends HookWidget {
                     Expanded(
                       flex: 7,
                       child: FieldSettingContainer(
-                        backgroundColor: backgroundColor.value,
-                        onColorChanged: (color) =>
-                            backgroundColor.value = color,
+                        field: buttonField.value,
+                        onColorChanged: (color) {
+                          final buttonStyle =
+                              ElevatedButton.styleFrom(backgroundColor: color);
+                          final cloned = buttonField.value.clone();
+                          cloned.buttonStyle = buttonStyle;
+                          buttonField.value = cloned;
+                        },
                       ),
                     ),
                   ],

--- a/lib/shirley.dart
+++ b/lib/shirley.dart
@@ -100,6 +100,11 @@ class Shirley extends HookWidget {
                       flex: 7,
                       child: FieldSettingContainer(
                         field: buttonField.value,
+                        onTextChanged: (text) {
+                          final cloned = buttonField.value.clone();
+                          cloned.text = text;
+                          buttonField.value = cloned;
+                        },
                         onTextStyleFieldChanged: (textStyle) {
                           final cloned = buttonField.value.clone();
                           cloned.textStyle = textStyle;

--- a/lib/shirley.dart
+++ b/lib/shirley.dart
@@ -100,6 +100,11 @@ class Shirley extends HookWidget {
                       flex: 7,
                       child: FieldSettingContainer(
                         field: buttonField.value,
+                        onTextStyleFieldChanged: (textStyle) {
+                          final cloned = buttonField.value.clone();
+                          cloned.textStyle = textStyle;
+                          buttonField.value = cloned;
+                        },
                         onColorChanged: (color) {
                           final buttonStyle =
                               ElevatedButton.styleFrom(backgroundColor: color);

--- a/lib/src/common/widget.dart
+++ b/lib/src/common/widget.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+void afterBuild(FrameCallback frameCallback) =>
+    WidgetsBinding.instance.addPostFrameCallback(frameCallback);

--- a/lib/src/model/button_field.dart
+++ b/lib/src/model/button_field.dart
@@ -18,10 +18,6 @@ class ButtonField {
       ..textStyle = textStyle;
   }
 
-  TextStyle? cloneTextStyle() {
-    return TextStyle(fontSize: textStyle?.fontSize);
-  }
-
   String toCode() {
     final elevatedButton = refer('ElevatedButton').newInstance(
       [],

--- a/lib/src/model/button_field.dart
+++ b/lib/src/model/button_field.dart
@@ -18,13 +18,21 @@ class ButtonField {
       ..textStyle = textStyle;
   }
 
+  TextStyle? cloneTextStyle() {
+    return TextStyle(fontSize: textStyle?.fontSize);
+  }
+
   String toCode() {
     final elevatedButton = refer('ElevatedButton').newInstance(
       [],
       {
         'child': refer('Text').newInstance([
           literalString(text ?? ''),
-        ]),
+        ], {
+          'style': refer('TextStyle').call([], {
+            'fontSize': literalNum(textStyle?.fontSize ?? 0),
+          }),
+        }),
         'style': refer('ElevatedButton.styleFrom').call([], {
           'backgroundColor': refer('Colors.fromRGBO').call([
             literalNum(backgroundColor?.redValue ?? 0),
@@ -73,7 +81,10 @@ class ButtonField {
     "child": {
       "type": "text",
       "args": {
-        "text": "$text"
+        "text": "$text",
+        "style": {
+          "fontSize": "${textStyle?.fontSize}"
+        }
       }
     },
     "style": {

--- a/lib/src/model/button_field.dart
+++ b/lib/src/model/button_field.dart
@@ -1,0 +1,85 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:shirley/src/extension/color.dart';
+
+class ButtonField {
+  String? text;
+  TextStyle? textStyle;
+  ButtonStyle? buttonStyle;
+
+  ButtonField({this.text, this.textStyle, this.buttonStyle});
+
+  Color? get backgroundColor => buttonStyle?.backgroundColor?.resolve({});
+
+  ButtonField clone() {
+    return ButtonField()
+      ..buttonStyle = buttonStyle
+      ..text = text
+      ..textStyle = textStyle;
+  }
+
+  String toCode() {
+    final elevatedButton = refer('ElevatedButton').newInstance(
+      [],
+      {
+        'child': refer('Text').newInstance([
+          literalString(text ?? ''),
+        ]),
+        'style': refer('ElevatedButton.styleFrom').call([], {
+          'backgroundColor': refer('Colors.fromRGBO').call([
+            literalNum(backgroundColor?.redValue ?? 0),
+            literalNum(backgroundColor?.greenValue ?? 0),
+            literalNum(backgroundColor?.blueValue ?? 0),
+            literalNum(1)
+          ])
+        }),
+        'onPressed': Method((builder) => builder
+          ..lambda = true
+          ..body = Code('() {}')).closure,
+      },
+    );
+
+    final parameter = Parameter(
+      (builder) => builder
+        ..name = 'context'
+        ..type = refer('BuildContext'),
+    );
+
+    final methods = [
+      Method(
+        (builder) => builder
+          ..name = 'build'
+          ..requiredParameters.add(parameter)
+          ..body = Code('return ${elevatedButton.accept(DartEmitter())};')
+          ..returns = refer('Widget'),
+      ),
+    ];
+
+    final shirleyButtonClass = Class((builder) {
+      builder
+        ..name = 'ShirleyButton'
+        ..extend = refer('StatelessWidget')
+        ..methods.addAll(methods);
+    });
+
+    return '${shirleyButtonClass.accept(DartEmitter.scoped())}';
+  }
+
+  String toJsonString() {
+    return '''
+{
+  "type": "elevated_button",
+  "args": {
+    "child": {
+      "type": "text",
+      "args": {
+        "text": "$text"
+      }
+    },
+    "style": {
+      "backgroundColor": "${buttonStyle?.backgroundColor?.resolve({})?.toHex}"
+    }
+  }
+}''';
+  }
+}

--- a/lib/src/ui/components/field_setting/quick_setting_view.dart
+++ b/lib/src/ui/components/field_setting/quick_setting_view.dart
@@ -1,25 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:shirley/src/model/button_field.dart';
 import 'package:shirley/src/ui/components/dialog/color_picker_dialog.dart';
 
 class QuickSettingView extends HookWidget {
   const QuickSettingView({
     super.key,
-    required this.backgroundColor,
+    required this.field,
     this.onColorChanged,
   });
 
-  final Color backgroundColor;
+  final ButtonField field;
   final void Function(Color)? onColorChanged;
 
   @override
   Widget build(BuildContext context) {
     final buttonTextEditingController =
-        useTextEditingController(text: 'content');
-    final fontSizeTextEditingController = useTextEditingController(text: '12');
+        useTextEditingController(text: field.text ?? '');
+    final fontSizeTextEditingController = useTextEditingController(
+      text: field.textStyle?.fontSize?.toString() ?? '',
+    );
 
-    final content = useState('');
-    final fontSize = useState('');
+    final content = useState(field.text ?? '');
+    final fontSize = useState(field.textStyle?.fontSize?.toString() ?? '');
 
     return Column(
       spacing: 16.0,
@@ -31,7 +34,7 @@ class QuickSettingView extends HookWidget {
               onTap: () async {
                 await showColorPickerDialog(
                   context,
-                  pickerColor: backgroundColor,
+                  pickerColor: field.backgroundColor ?? Colors.orange,
                   onColorChanged: (color) {
                     onColorChanged?.call(color);
                   },
@@ -44,7 +47,7 @@ class QuickSettingView extends HookWidget {
                   Text('Background Color', style: TextStyle(fontSize: 14)),
                   Container(
                     decoration: BoxDecoration(
-                      color: backgroundColor,
+                      color: field.backgroundColor ?? Colors.orange,
                       border: Border.all(width: 2, color: Colors.white),
                       borderRadius: BorderRadius.circular(4),
                     ),

--- a/lib/src/ui/components/field_setting/quick_setting_view.dart
+++ b/lib/src/ui/components/field_setting/quick_setting_view.dart
@@ -9,13 +9,13 @@ class QuickSettingView extends HookWidget {
     required this.field,
     this.onTextChanged,
     this.onTextStyleFieldChanged,
-    this.onButtonStyleChanged,
+    this.onButtonStyleFieldChanged,
   });
 
   final ButtonField field;
   final void Function(String)? onTextChanged;
   final void Function(TextStyle?)? onTextStyleFieldChanged;
-  final void Function(ButtonStyle?)? onButtonStyleChanged;
+  final void Function(ButtonStyle?)? onButtonStyleFieldChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -43,7 +43,7 @@ class QuickSettingView extends HookWidget {
                     final merged = field.buttonStyle?.merge(
                       ElevatedButton.styleFrom(backgroundColor: color),
                     );
-                    onButtonStyleChanged?.call(merged);
+                    onButtonStyleFieldChanged?.call(merged);
                   },
                 );
               },

--- a/lib/src/ui/components/field_setting/quick_setting_view.dart
+++ b/lib/src/ui/components/field_setting/quick_setting_view.dart
@@ -9,13 +9,13 @@ class QuickSettingView extends HookWidget {
     required this.field,
     this.onTextChanged,
     this.onTextStyleFieldChanged,
-    this.onColorChanged,
+    this.onButtonStyleChanged,
   });
 
   final ButtonField field;
   final void Function(String)? onTextChanged;
   final void Function(TextStyle?)? onTextStyleFieldChanged;
-  final void Function(Color)? onColorChanged;
+  final void Function(ButtonStyle?)? onButtonStyleChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +40,10 @@ class QuickSettingView extends HookWidget {
                   context,
                   pickerColor: field.backgroundColor ?? Colors.orange,
                   onColorChanged: (color) {
-                    onColorChanged?.call(color);
+                    final merged = field.buttonStyle?.merge(
+                      ElevatedButton.styleFrom(backgroundColor: color),
+                    );
+                    onButtonStyleChanged?.call(merged);
                   },
                 );
               },

--- a/lib/src/ui/components/field_setting/quick_setting_view.dart
+++ b/lib/src/ui/components/field_setting/quick_setting_view.dart
@@ -7,11 +7,13 @@ class QuickSettingView extends HookWidget {
   const QuickSettingView({
     super.key,
     required this.field,
+    this.onTextChanged,
     this.onTextStyleFieldChanged,
     this.onColorChanged,
   });
 
   final ButtonField field;
+  final void Function(String)? onTextChanged;
   final void Function(TextStyle?)? onTextStyleFieldChanged;
   final void Function(Color)? onColorChanged;
 
@@ -71,6 +73,7 @@ class QuickSettingView extends HookWidget {
               controller: buttonTextEditingController,
               onChanged: (value) {
                 content.value = value;
+                onTextChanged?.call(value);
               },
             ),
           ),

--- a/lib/src/ui/components/field_setting/quick_setting_view.dart
+++ b/lib/src/ui/components/field_setting/quick_setting_view.dart
@@ -7,10 +7,12 @@ class QuickSettingView extends HookWidget {
   const QuickSettingView({
     super.key,
     required this.field,
+    this.onTextStyleFieldChanged,
     this.onColorChanged,
   });
 
   final ButtonField field;
+  final void Function(TextStyle?)? onTextStyleFieldChanged;
   final void Function(Color)? onColorChanged;
 
   @override
@@ -81,6 +83,14 @@ class QuickSettingView extends HookWidget {
               controller: fontSizeTextEditingController,
               onChanged: (value) {
                 fontSize.value = value;
+                final parsed = int.tryParse(value);
+                if (parsed == null) {
+                  return;
+                }
+
+                final merged = field.textStyle
+                    ?.merge(TextStyle(fontSize: parsed.toDouble()));
+                onTextStyleFieldChanged?.call(merged);
               },
             ),
           ),

--- a/lib/src/ui/components/field_setting_container.dart
+++ b/lib/src/ui/components/field_setting_container.dart
@@ -11,13 +11,13 @@ class FieldSettingContainer extends HookWidget {
     required this.field,
     this.onTextChanged,
     this.onTextStyleFieldChanged,
-    this.onColorChanged,
+    this.onButtonStyleChanged,
   });
 
   final ButtonField field;
   final void Function(String)? onTextChanged;
   final void Function(TextStyle?)? onTextStyleFieldChanged;
-  final void Function(Color)? onColorChanged;
+  final void Function(ButtonStyle?)? onButtonStyleChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +59,7 @@ class FieldSettingContainer extends HookWidget {
                     field: field,
                     onTextChanged: onTextChanged,
                     onTextStyleFieldChanged: onTextStyleFieldChanged,
-                    onColorChanged: onColorChanged,
+                    onButtonStyleChanged: onButtonStyleChanged,
                   ),
                   BodySettingView(),
                   TextSettingView(),

--- a/lib/src/ui/components/field_setting_container.dart
+++ b/lib/src/ui/components/field_setting_container.dart
@@ -9,11 +9,13 @@ class FieldSettingContainer extends HookWidget {
   const FieldSettingContainer({
     super.key,
     required this.field,
+    this.onTextChanged,
     this.onTextStyleFieldChanged,
     this.onColorChanged,
   });
 
   final ButtonField field;
+  final void Function(String)? onTextChanged;
   final void Function(TextStyle?)? onTextStyleFieldChanged;
   final void Function(Color)? onColorChanged;
 
@@ -55,6 +57,7 @@ class FieldSettingContainer extends HookWidget {
                 children: [
                   QuickSettingView(
                     field: field,
+                    onTextChanged: onTextChanged,
                     onTextStyleFieldChanged: onTextStyleFieldChanged,
                     onColorChanged: onColorChanged,
                   ),

--- a/lib/src/ui/components/field_setting_container.dart
+++ b/lib/src/ui/components/field_setting_container.dart
@@ -9,10 +9,12 @@ class FieldSettingContainer extends HookWidget {
   const FieldSettingContainer({
     super.key,
     required this.field,
+    this.onTextStyleFieldChanged,
     this.onColorChanged,
   });
 
   final ButtonField field;
+  final void Function(TextStyle?)? onTextStyleFieldChanged;
   final void Function(Color)? onColorChanged;
 
   @override
@@ -53,6 +55,7 @@ class FieldSettingContainer extends HookWidget {
                 children: [
                   QuickSettingView(
                     field: field,
+                    onTextStyleFieldChanged: onTextStyleFieldChanged,
                     onColorChanged: onColorChanged,
                   ),
                   BodySettingView(),

--- a/lib/src/ui/components/field_setting_container.dart
+++ b/lib/src/ui/components/field_setting_container.dart
@@ -11,13 +11,13 @@ class FieldSettingContainer extends HookWidget {
     required this.field,
     this.onTextChanged,
     this.onTextStyleFieldChanged,
-    this.onButtonStyleChanged,
+    this.onButtonStyleFieldChanged,
   });
 
   final ButtonField field;
   final void Function(String)? onTextChanged;
   final void Function(TextStyle?)? onTextStyleFieldChanged;
-  final void Function(ButtonStyle?)? onButtonStyleChanged;
+  final void Function(ButtonStyle?)? onButtonStyleFieldChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +59,7 @@ class FieldSettingContainer extends HookWidget {
                     field: field,
                     onTextChanged: onTextChanged,
                     onTextStyleFieldChanged: onTextStyleFieldChanged,
-                    onButtonStyleChanged: onButtonStyleChanged,
+                    onButtonStyleFieldChanged: onButtonStyleFieldChanged,
                   ),
                   BodySettingView(),
                   TextSettingView(),

--- a/lib/src/ui/components/field_setting_container.dart
+++ b/lib/src/ui/components/field_setting_container.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:shirley/src/model/button_field.dart';
 import 'package:shirley/src/ui/components/field_setting/body_setting_view.dart';
 import 'package:shirley/src/ui/components/field_setting/quick_setting_view.dart';
 import 'package:shirley/src/ui/components/field_setting/text_setting_view.dart';
@@ -7,11 +8,11 @@ import 'package:shirley/src/ui/components/field_setting/text_setting_view.dart';
 class FieldSettingContainer extends HookWidget {
   const FieldSettingContainer({
     super.key,
-    required this.backgroundColor,
+    required this.field,
     this.onColorChanged,
   });
 
-  final Color backgroundColor;
+  final ButtonField field;
   final void Function(Color)? onColorChanged;
 
   @override
@@ -51,7 +52,7 @@ class FieldSettingContainer extends HookWidget {
                 physics: const NeverScrollableScrollPhysics(),
                 children: [
                   QuickSettingView(
-                    backgroundColor: backgroundColor,
+                    field: field,
                     onColorChanged: onColorChanged,
                   ),
                   BodySettingView(),

--- a/lib/src/ui/components/preview/preview_code_view.dart
+++ b/lib/src/ui/components/preview/preview_code_view.dart
@@ -1,3 +1,4 @@
+import 'package:dart_style/dart_style.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -24,6 +25,17 @@ class PreviewCodeView extends HookWidget {
       return;
     }, [theme]);
 
+    final formattedCode = useState('');
+
+    useEffect(() {
+      formattedCode.value = DartFormatter(
+        languageVersion: DartFormatter.latestLanguageVersion,
+        indent: 2,
+      ).format(code);
+
+      return;
+    }, [code]);
+
     final copying = useState(false);
 
     const secondaryColor = Color.fromRGBO(245, 88, 123, 1);
@@ -34,7 +46,7 @@ class PreviewCodeView extends HookWidget {
         Padding(
           padding: const EdgeInsets.all(16),
           child: SelectableText.rich(
-            hightlighter.value.highlight(code),
+            hightlighter.value.highlight(formattedCode.value),
             style: TextStyle(fontSize: 14),
           ),
         ),

--- a/lib/src/ui/components/preview_container.dart
+++ b/lib/src/ui/components/preview_container.dart
@@ -18,14 +18,6 @@ class PreviewContainer extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hightlighter = useState(Highlighter(language: 'dart', theme: theme));
-
-    useEffect(() {
-      hightlighter.value = Highlighter(language: 'dart', theme: theme);
-
-      return;
-    }, [theme]);
-
     const primaryColor = Color.fromRGBO(228, 23, 73, 1);
 
     return DefaultTabController(


### PR DESCRIPTION
It would be difficult to declare each field in one value notifier since all of them are assumed to be more than 10. Letting  `ButtonField` model have all the fields resolves issue. (as well as it is easy to write test code for converting into code and json) 