### PR TITLE
Fix description on pubspec.yml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shirley
-description: "A new Flutter project."
+description: Button Maker for Flutter DevTools Extension
 homepage: https://offich.me
 repository: https://github.com/offich/shirley
 


### PR DESCRIPTION
publish command threw the error below. changed description

```
Message from server: `description` contains a generic text fragment coming from package templates (`A new Flutter project`). Please follow the guides to describe your package: https://dart.dev/tools/pub/pubspec#description
```