### PR TITLE
feat: add automated production release PR workflow

### DIFF
--- a/.github/templates/git-pr-release.erb
+++ b/.github/templates/git-pr-release.erb
@@ -1,0 +1,9 @@
+【Production Release】<%= Time.now.strftime('%Y-%m-%d %H:%M') %>
+
+## Description
+Distribute DevTool Extension :rocket:
+
+## Target PR
+<% pull_requests.each do |pr| -%>
+- #<%= pr.number %> by <%= pr.mention %>
+<% end -%>

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,33 @@
+name: Create Production Release PR
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - run: gem install --no-document git-pr-release
+
+      - run: git-pr-release
+        env:
+          GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_PR_RELEASE_BRANCH_PRODUCTION: release
+          GIT_PR_RELEASE_BRANCH_STAGING: develop
+          GIT_PR_RELEASE_LABELS: release
+          GIT_PR_RELEASE_TEMPLATE: .github/templates/git-pr-release.erb
+          TZ: Asia/Tokyo


### PR DESCRIPTION
# Description
Added a GitHub Actions workflow that automatically creates a release PR from `develop` → `release`
whenever changes are pushed to the `develop` branch. The PR body is generated using the `git-pr-release` gem with an ERB template.

# What was done
- Added `.github/workflows/create-release-pr.yml`
  - Automatically creates a release PR targeting the `release` branch via `git-pr-release` on every push to `develop`
  - Uses `actions/checkout@v6.0.2` and `ruby/setup-ruby@v1.299.0` pinned to commit hashes
- Added `.github/templates/git-pr-release.erb`
  - Release PR body template that automatically lists all included PRs

# What was NOT done
- Creating the `release` branch (required separately)
- Configuring auto-merge for the release PR

# Operation Confirmation

## Setup & Steps
1. Ensure the `release` branch exists
2. Push to the `develop` branch — the workflow will trigger and automatically create a release PR from `develop` → `release`

# Notes / Related URLs
- [git-pr-release](https://github.com/x-motemen/git-pr-release)