### PR TITLE
dev: install cider and reformat CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
-## 0.0.1
+## [0.0.1] - 2025-03-11
 
-  * Official release.
-  * Rename prefix on Snackbar widget.
-  * Improve score on pub dev.
-  * Fix dart sdk version in CI.
+### Added
 
-## 0.0.1-dev.1
+  - Official release.
 
-  * Initial release. This package is under construction.
+### Changed
+
+  - Rename prefix on Snackbar widget.
+  - Improve score on pub dev.
+
+### Fixed
+
+  - Fix dart sdk version in CI.
+
+## [0.0.1-dev.1] - 2025-02-28
+
+### Added
+
+  - Initial release. This package is under construction.
+
+[0.0.1]: https://github.com/offich/shirley/compare/v0.0.1-dev.1...v0.0.1
+[0.0.1-dev.1]: https://github.com/offich/shirley/releases/tag/v0.0.1-dev.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.12.6"
+  change:
+    dependency: transitive
+    description:
+      name: change
+      sha256: "3bda1ce98526b21927cdea05688563c7065fd7e66d1abbe176c354fef3b2057b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.5"
   characters:
     dependency: transitive
     description:
@@ -89,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  cider:
+    dependency: "direct dev"
+    description:
+      name: cider
+      sha256: "27b9cd9526c70d6cd47299cd644cddaac8102e5f9783ef4bb440840743271883"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.10"
   cli_util:
     dependency: transitive
     description:
@@ -576,6 +592,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.3.0"
+  marker:
+    dependency: transitive
+    description:
+      name: marker
+      sha256: "3dadd01f3b0ffae148ffb3b1bc04290a98e54a465cddbab59727bd2a9fe57750"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   matcher:
     dependency: transitive
     description:
@@ -1045,6 +1069,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  version_manipulation:
+    dependency: transitive
+    description:
+      name: version_manipulation
+      sha256: e90782d610bde19765d2808ec06bc8ed9e04640a4dd07d1a3d370728ce9dae7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: 6.0.0
   pana: 0.23.11
+  cider: 0.2.10
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
# Description
Installed [cider](https://pub.dev/packages/cider) as a dev dependency for automated changelog management, and reformatted `CHANGELOG.md` to follow the Keep a Changelog format (matching `CHANGELOG2.md`).

# What was done
- Added `cider: 0.2.10` as a dev dependency
- Reformatted `CHANGELOG.md` to `## [version] - date` heading style
- Added `### Added` / `### Changed` / `### Fixed` sections for each release
- Added reference links at the bottom of `CHANGELOG.md`

# What was NOT done
- No changes to app functionality or Dart/Flutter source code

# Operation Confirmation

## Prerequisites & Steps
No special steps required. To use cider for changelog management:
```bash
fvm dart run cider --help
```

# Notes / Related URLs
- https://pub.dev/packages/cider